### PR TITLE
COLORTHEME-3: Cotton-Candy makes panel-headings unreadable

### DIFF
--- a/color-theme-cottoncandy/src/main/resources/FlamingoThemes/CottonCandy.xml
+++ b/color-theme-cottoncandy/src/main/resources/FlamingoThemes/CottonCandy.xml
@@ -905,10 +905,10 @@
       <btn-warning-color/>
     </property>
     <property>
-      <component-active-bg/>
+      <component-active-bg>@list-group-hover-bg</component-active-bg>
     </property>
     <property>
-      <component-active-color/>
+      <component-active-color>@list-group-link-hover-color</component-active-color>
     </property>
     <property>
       <dropdown-bg>#fafafa</dropdown-bg>
@@ -969,6 +969,8 @@
     </property>
     <property>
       <lessCode>@xwiki-border-color: #E8E8E8;
+/* Administration: Vertical Menus */
+@list-group-active-border: @list-group-border;
 
 #menuview .actionmenu, 
 #footerglobal {
@@ -1073,7 +1075,7 @@
       <logo>xwiki.png</logo>
     </property>
     <property>
-      <navbar-default-bg>#fff</navbar-default-bg>
+      <navbar-default-bg>#02b3e4</navbar-default-bg>
     </property>
     <property>
       <navbar-default-color>#9d9fa2</navbar-default-color>
@@ -1085,7 +1087,7 @@
       <navbar-default-link-active-color>rgba(255,255,255,.6)</navbar-default-link-active-color>
     </property>
     <property>
-      <navbar-default-link-color/>
+      <navbar-default-link-color>#fff</navbar-default-link-color>
     </property>
     <property>
       <navbar-default-link-hover-bg>transparent</navbar-default-link-hover-bg>

--- a/color-theme-cottoncandy/src/main/resources/FlamingoThemes/CottonCandy.xml
+++ b/color-theme-cottoncandy/src/main/resources/FlamingoThemes/CottonCandy.xml
@@ -1078,7 +1078,7 @@
       <navbar-default-bg>#02b3e4</navbar-default-bg>
     </property>
     <property>
-      <navbar-default-color>#9d9fa2</navbar-default-color>
+      <navbar-default-color>#fff</navbar-default-color>
     </property>
     <property>
       <navbar-default-link-active-bg>transparent</navbar-default-link-active-bg>

--- a/color-theme-cottoncandy/src/main/resources/FlamingoThemes/CottonCandy.xml
+++ b/color-theme-cottoncandy/src/main/resources/FlamingoThemes/CottonCandy.xml
@@ -1085,7 +1085,7 @@
       <navbar-default-link-active-color>rgba(255,255,255,.6)</navbar-default-link-active-color>
     </property>
     <property>
-      <navbar-default-link-color>#fff</navbar-default-link-color>
+      <navbar-default-link-color/>
     </property>
     <property>
       <navbar-default-link-hover-bg>transparent</navbar-default-link-hover-bg>


### PR DESCRIPTION
Issue [COLORTHEME-3](https://jira.xwiki.org/browse/COLORTHEME-3)

old:
![unreadable_navigation_bar](https://user-images.githubusercontent.com/23619087/114193677-0dec7b00-994f-11eb-8d9b-c2651ceef2c0.PNG)
new:
![new_navigation_bar](https://user-images.githubusercontent.com/23619087/114193721-18a71000-994f-11eb-8e18-198017bf4a01.PNG)

The text was unreadable because it was white text on a white background. Looking at the Iceberg color theme as an example, I have changed the background color of the collapsed panel header (e.g. "Look & Feel") to be blue. It then didn't look right to have the active list-group-item (e.g. "Themes") also be blue, so I changed that to be gray in the same way that that is done in the Iceberg color theme.

I have visually checked for side effects as I do not 100% understand how the variables are used, and I only saw other changes in the drawer menu on the right:

old:
![old_administrator_bar](https://user-images.githubusercontent.com/23619087/114196673-e1862e00-9951-11eb-9b99-c1de668f46aa.PNG)
new:
![new_administrator_bar](https://user-images.githubusercontent.com/23619087/114196696-e6e37880-9951-11eb-9574-e0797061294d.PNG)

which also makes the "Log-out" text readable.

I hope these changes are okay, since they change the looks a bit by changing the background color.